### PR TITLE
Classify 'CHINA UNION PAY' as unionpay card

### DIFF
--- a/apps/capi/src/capi_real_handler.erl
+++ b/apps/capi/src/capi_real_handler.erl
@@ -405,6 +405,7 @@ encode_binbase_payment_system(<<"AMERICAN EXPRESS">>)          -> amex;
 encode_binbase_payment_system(<<"DINERS CLUB INTERNATIONAL">>) -> dinersclub;
 encode_binbase_payment_system(<<"DISCOVER">>)                  -> discover;
 encode_binbase_payment_system(<<"UNIONPAY">>)                  -> unionpay;
+encode_binbase_payment_system(<<"CHINA UNION PAY">>)           -> unionpay;
 encode_binbase_payment_system(<<"JCB">>)                       -> jcb;
 encode_binbase_payment_system(<<"NSPK MIR">>)                  -> nspkmir;
 encode_binbase_payment_system(_) ->


### PR DESCRIPTION
As of #41.