### PR TITLE
ED-124: +provider&id key +capi_handler:respond +serviceID 

### DIFF
--- a/config/sys.config
+++ b/config/sys.config
@@ -84,18 +84,15 @@
             }
         }},
         {fallback_merchant_map, #{
-            <<"15666243338125315447">> => #{
-                provider => googlepay,
+            {googlepay, <<"15666243338125315447">>} => #{
                 realm => live,
                 expiration => {2022, 1, 1}
             },
-            <<"dubtv-test">> => #{
-                provider => googlepay,
+            {googlepay, <<"dubtv-test">>} => #{
                 realm => test,
                 expiration => {2022, 1, 1}
             },
-            <<"supermoney">> => #{
-                provider => yandexpay,
+            {yandexpay, <<"supermoney">>} => #{
                 party => <<"mapped_party_id">>,
                 shop => <<"mapped_shop_id">>
             }


### PR DESCRIPTION
- использование {provider, id} в качестве ключа для fallback merchant id
- использование serviceID у samsung в качестве merchant id для fallback
- замена исключения invalid_merchant_id на cap_handle:respond как в capi